### PR TITLE
Updated version of LibreHardwareMonitor to 0.9.4

### DIFF
--- a/LibreHardwareMonitorAfterburnerPlugin.csproj
+++ b/LibreHardwareMonitorAfterburnerPlugin.csproj
@@ -117,10 +117,10 @@
       <Version>3.0.41</Version>
     </PackageReference>
     <PackageReference Include="LibreHardwareMonitorLib">
-      <Version>0.9.2</Version>
+      <Version>0.9.4</Version>
     </PackageReference>
     <PackageReference Include="System.Management">
-      <Version>7.0.0</Version>
+      <Version>9.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Also updated version of System.Management as LibreHardwareMonitor depends on 9.0.0 now.

This should fix CPU temp monitoring on Ryzen 9000 series processors.

Resolves issues #15 and #16 