### PR TITLE
Update workflow setup-msbuild action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Restore
         run: msbuild LibreHardwareMonitorAfterburnerPlugin.csproj -t:Restore -p:Configuration=Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           Add-Content $env:GITHUB_STEP_SUMMARY "### Version: $ver"
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Restore
         run: msbuild LibreHardwareMonitorAfterburnerPlugin.csproj -t:Restore -p:Configuration=Release


### PR DESCRIPTION
There is a warning that microsoft/setup-msbuild@v2 uses Node.js 20 which is deprecated on Github Actions. Updating to v3 should remove deprecation warning in the workflow runs.